### PR TITLE
security: require auth on settings/health endpoints and harden file paths

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,5 @@
+import secrets
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional, Any
 from sqlalchemy.orm import Session
@@ -50,7 +52,12 @@ class Settings(BaseSettings):
     allowed_extensions: str = "pdf,png,jpg,jpeg,tiff,bmp,txt,text"
     
     # Security
-    secret_key: str = "your-secret-key-change-in-production"
+    # Do NOT ship a static, well-known default secret_key. Anything signed
+    # with this key would be forgeable by anyone who has read the source.
+    # When unset, a per-process random key is generated; admins should
+    # configure a stable value via the database settings table (the
+    # DatabaseSettings loader will override this).
+    secret_key: str = secrets.token_urlsafe(32)
     jwt_secret_key: Optional[str] = None  # JWT secret key for authentication
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30

--- a/app/routers/backup.py
+++ b/app/routers/backup.py
@@ -6,12 +6,38 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, Optional
 from pathlib import Path
 
+import re
+
 from ..database import get_db
 from ..models import User
 from ..services.auth_service import require_admin_flexible
 from ..services.backup_scheduler import backup_scheduler
 from ..utils.backup import restore_backup, list_backups
 from pydantic import BaseModel
+
+
+_BACKUP_DIR = Path("data/backups")
+_BACKUP_FILENAME_RE = re.compile(r"^[A-Za-z0-9._\-]+$")
+
+
+def _resolve_backup_path(backup_filename: str) -> Path:
+    """Resolve a user-supplied backup filename to a safe path.
+
+    Prevents path traversal by:
+    - rejecting filenames containing path separators / null bytes / dots
+      that would let the user escape the directory; and
+    - confirming the fully-resolved path stays inside the backups dir.
+    """
+    if not backup_filename or not _BACKUP_FILENAME_RE.fullmatch(backup_filename):
+        raise HTTPException(status_code=400, detail="Invalid backup filename")
+
+    base = _BACKUP_DIR.resolve()
+    candidate = (base / backup_filename).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid backup filename")
+    return candidate
 
 router = APIRouter()
 
@@ -211,11 +237,11 @@ def restore_backup_from_file(
 ) -> Dict[str, Any]:
     """Restore system from a backup file"""
     try:
-        # Validate backup file exists
-        backup_path = Path("data/backups") / backup_filename
+        # Validate backup file exists (with path-traversal protection)
+        backup_path = _resolve_backup_path(backup_filename)
         if not backup_path.exists():
             raise HTTPException(status_code=404, detail="Backup file not found")
-        
+
         # Perform restore
         restore_info = restore_backup(
             archive_path=backup_path,
@@ -256,13 +282,13 @@ def delete_backup_file(
 ) -> Dict[str, Any]:
     """Delete a backup file"""
     try:
-        backup_path = Path("data/backups") / backup_filename
+        backup_path = _resolve_backup_path(backup_filename)
         if not backup_path.exists():
             raise HTTPException(status_code=404, detail="Backup file not found")
-        
+
         # Get file size before deletion
         file_size_mb = backup_path.stat().st_size / (1024 * 1024)
-        
+
         # Delete the file
         backup_path.unlink()
         

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -372,9 +372,13 @@ async def upload_document(
         # Save file with secure permissions
         with open(staging_path, "wb") as buffer:
             buffer.write(content)
-        
-        # Set secure file permissions
-        set_secure_permissions(staging_path, is_private=False)
+
+        # Set secure file permissions. Uploaded documents frequently contain
+        # sensitive personal data (invoices, contracts, tax documents, etc.).
+        # We default to owner-only (0600) instead of world-readable (0644) so
+        # that other local users on the host can't read uploaded documents
+        # by browsing the filesystem.
+        set_secure_permissions(staging_path, is_private=True)
         
         # Log upload event
         from ..services.audit_service import log_audit_event

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ..database import get_db
 from ..config import get_settings
 from ..models import Document, Correspondent, Tag, DocType, User, AuditLog
+from ..services.auth_service import require_admin_flexible
 
 router = APIRouter()
 
@@ -253,8 +254,16 @@ async def simple_health_check() -> Dict[str, str]:
 
 
 @router.get("/metrics")
-async def system_metrics(db: Session = Depends(get_db)) -> Dict[str, Any]:
-    """System performance and resource metrics"""
+async def system_metrics(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
+) -> Dict[str, Any]:
+    """System performance and resource metrics (admin only).
+
+    Reveals CPU/RAM/disk usage, user counts, recent login counts and
+    process metadata. Anonymous callers should not be able to fingerprint
+    the host this way.
+    """
     try:
         # CPU metrics
         cpu_percent = psutil.cpu_percent(interval=1)
@@ -453,8 +462,16 @@ async def startup_check(db: Session = Depends(get_db)) -> Dict[str, Any]:
 
 
 @router.get("/security")
-async def security_status(db: Session = Depends(get_db)) -> Dict[str, Any]:
-    """Security-specific health checks"""
+async def security_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
+) -> Dict[str, Any]:
+    """Security-specific health checks (admin only).
+
+    Exposes user counts, admin counts, recent failed/successful login
+    counts, and filesystem permission information that helps an attacker
+    enumerate the install. Restricted to admins.
+    """
     security_status = {}
     
     # Authentication status

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -46,14 +46,29 @@ def health_check(db: Session = Depends(get_db)):
         }
 
 @router.get("/debug/azure")
-def debug_azure_settings(db: Session = Depends(get_db)):
-    """Debug endpoint to check Azure settings"""
+def debug_azure_settings(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
+):
+    """Debug endpoint to check Azure settings (admin only).
+
+    Even though the Azure API key is masked, this endpoint dumps the full
+    Azure deployment configuration (endpoint, deployment names) and other
+    raw settings, so it must require admin authentication.
+    """
     settings = get_settings(db)
     db_settings = db.query(SettingsModel).filter(
-        SettingsModel.key.in_(['ai_provider', 'azure_openai_api_key', 'azure_openai_endpoint', 
+        SettingsModel.key.in_(['ai_provider', 'azure_openai_api_key', 'azure_openai_endpoint',
                                'azure_openai_chat_deployment', 'azure_openai_embeddings_deployment'])
     ).all()
-    
+
+    # Mask any sensitive values in db_settings as well so we don't leak the
+    # raw api key from the settings table even to admins via this endpoint.
+    sensitive_keys = {"azure_openai_api_key", "openai_api_key", "jwt_secret_key", "secret_key"}
+    masked_db_settings = {
+        s.key: ("***" if s.key in sensitive_keys and s.value else s.value)
+        for s in db_settings
+    }
     return {
         "loaded_settings": {
             "ai_provider": settings.ai_provider,
@@ -62,7 +77,7 @@ def debug_azure_settings(db: Session = Depends(get_db)):
             "azure_chat_deployment": settings.azure_openai_chat_deployment,
             "azure_embeddings_deployment": settings.azure_openai_embeddings_deployment
         },
-        "db_settings": {s.key: s.value for s in db_settings}
+        "db_settings": masked_db_settings,
     }
 
 
@@ -97,11 +112,18 @@ def get_all_settings(
     return settings
 
 @router.get("/setup-config")
-def get_setup_config(db: Session = Depends(get_db)):
-    """Get current configuration for setup wizard"""
+def get_setup_config(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
+):
+    """Get current configuration for setup wizard (admin only).
+
+    This endpoint returns OpenAI and Azure OpenAI API keys in cleartext, so
+    it must require admin authentication.
+    """
     try:
         config = get_settings(db)
-        
+
         return {
             "ai_provider": config.ai_provider,
             "openai_api_key": config.openai_api_key if config.openai_api_key else "",
@@ -117,7 +139,7 @@ def get_setup_config(db: Session = Depends(get_db)):
             "storage_folder": config.storage_folder,
             "data_folder": config.data_folder
         }
-        
+
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -164,9 +186,16 @@ def save_configuration(
 @router.get("/extended")
 def get_extended_settings(
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_permission_flexible("settings.read"))
+    current_user: User = Depends(require_admin_flexible),
 ) -> ExtendedSettingsResponse:
-    """Get all settings with additional computed values"""
+    """Get all settings with additional computed values (admin only).
+
+    Previously required only the ``settings.read`` permission, which the
+    default ``editor`` role grants. That meant any non-admin editor could
+    read the cleartext OpenAI/Azure API keys and the ``secret_key`` via
+    this endpoint. Restricted to admins to fix the privilege-escalation
+    path.
+    """
     try:
         config = get_settings(db)
         
@@ -255,8 +284,16 @@ def update_extended_settings(
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/ai-provider/status")
-def get_ai_provider_status(db: Session = Depends(get_db)) -> AIProviderStatus:
-    """Get current AI provider configuration and test connection"""
+def get_ai_provider_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
+) -> AIProviderStatus:
+    """Get current AI provider configuration and test connection (admin only).
+
+    Discloses which AI provider is configured, deployment/model names, and
+    actively attempts an outbound API call. Restricted to admins to avoid
+    information disclosure and unauthenticated outbound traffic.
+    """
     try:
         config = get_settings(db)
         
@@ -531,9 +568,10 @@ def update_openai_config(
 @router.post("/config/ai-limits")
 def update_ai_limits(
     ai_limits: Dict[str, int],
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
 ):
-    """Update AI service limits"""
+    """Update AI service limits (admin only)."""
     text_limit = ai_limits.get("text_limit")
     context_limit = ai_limits.get("context_limit")
     
@@ -554,9 +592,14 @@ def update_ai_limits(
 @router.post("/config/file-settings")
 def update_file_settings(
     file_settings: Dict[str, Any],
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
 ):
-    """Update file handling settings"""
+    """Update file handling settings (admin only).
+
+    Changing upload size limits or allowed extensions affects the system's
+    security posture, so this is restricted to admins.
+    """
     max_size = file_settings.get("max_file_size")
     extensions = file_settings.get("allowed_extensions")
     
@@ -571,9 +614,15 @@ def update_file_settings(
 @router.post("/config/ocr-tools")
 def update_ocr_tools(
     ocr_tools: Dict[str, str],
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
 ):
-    """Update OCR tool paths"""
+    """Update OCR tool paths (admin only).
+
+    These paths point at executables that the server invokes; allowing
+    unauthenticated callers to change them would be a remote-code-execution
+    primitive.
+    """
     tesseract_path = ocr_tools.get("tesseract_path")
     poppler_path = ocr_tools.get("poppler_path")
     
@@ -594,9 +643,14 @@ def update_ocr_tools(
 @router.post("/config/folders")
 def update_folder_paths(
     folders: Dict[str, str],
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
 ):
-    """Update folder paths"""
+    """Update folder paths (admin only).
+
+    Storage/staging/data folders control where uploaded documents live;
+    changing them could be used to redirect writes or hijack stored files.
+    """
     updated = []
     
     for key in ["root_folder", "staging_folder", "storage_folder", "data_folder", "logs_folder"]:
@@ -612,28 +666,42 @@ def update_folder_paths(
     return {"message": f"Updated folders: {', '.join(updated)}", "updated": updated}
 
 @router.get("/export")
-def export_configuration(db: Session = Depends(get_db)) -> ExportConfigResponse:
-    """Export all configuration settings"""
+def export_configuration(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
+) -> ExportConfigResponse:
+    """Export all configuration settings (admin only).
+
+    The settings table contains the OpenAI/Azure API keys and the JWT
+    secret in cleartext. Without admin authentication this endpoint
+    leaks every credential the application uses.
+    """
     try:
         # Get all settings from database
         db_settings = db.query(SettingsModel).all()
         settings_dict = {setting.key: setting.value for setting in db_settings}
-        
+
         return ExportConfigResponse(
             version="1.0",
             exported_at=datetime.now(),
             settings=settings_dict
         )
-        
+
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/import")
 async def import_configuration(
     file: UploadFile = File(...),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
 ) -> Dict[str, Any]:
-    """Import configuration from JSON file"""
+    """Import configuration from JSON file (admin only).
+
+    Without authentication, an anonymous attacker could overwrite every
+    setting (including API keys, JWT secret, admin-controlled paths) by
+    POSTing a crafted JSON payload.
+    """
     try:
         # Read and parse JSON file
         content = await file.read()
@@ -665,9 +733,14 @@ async def import_configuration(
 @router.post("/backup")
 async def backup_system(
     background_tasks: BackgroundTasks,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin_flexible),
 ) -> Dict[str, str]:
-    """Create a full system backup"""
+    """Create a full system backup (admin only).
+
+    The exported backup contains all configuration settings, including the
+    cleartext OpenAI/Azure API keys and the JWT secret.
+    """
     try:
         backup_id = datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_dir = Path("data/backups") / backup_id
@@ -716,13 +789,37 @@ async def backup_system(
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/backup/{backup_id}")
-def download_backup(backup_id: str):
-    """Download a backup file"""
-    zip_path = Path("data/backups") / f"backup_{backup_id}.zip"
-    
+def download_backup(
+    backup_id: str,
+    current_user: User = Depends(require_admin_flexible),
+):
+    """Download a backup file (admin only).
+
+    The backup archive contains every configuration setting (including
+    OpenAI/Azure keys and the JWT secret), so this must require admin
+    authentication. The backup_id is also validated to prevent path
+    traversal: the resolved path must stay inside data/backups, and the
+    id is constrained to a safe character set.
+    """
+    import re
+
+    # Restrict backup_id to a safe character set; the timestamp generator
+    # above only emits digits and underscores, so this is sufficient.
+    if not re.fullmatch(r"[A-Za-z0-9_\-]+", backup_id):
+        raise HTTPException(status_code=400, detail="Invalid backup id")
+
+    backups_base = Path("data/backups").resolve()
+    zip_path = (backups_base / f"backup_{backup_id}.zip").resolve()
+
+    # Ensure the resolved path stays inside the backups directory.
+    try:
+        zip_path.relative_to(backups_base)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid backup id")
+
     if not zip_path.exists():
         raise HTTPException(status_code=404, detail="Backup not found")
-    
+
     return FileResponse(
         path=zip_path,
         media_type="application/zip",
@@ -730,8 +827,14 @@ def download_backup(backup_id: str):
     )
 
 @router.get("/logs/download")
-def download_logs():
-    """Download all log files as a zip archive"""
+def download_logs(
+    current_user: User = Depends(require_admin_flexible),
+):
+    """Download all log files as a zip archive (admin only).
+
+    Logs typically include request paths, user identifiers, IP addresses
+    and error stack traces — all sensitive operational data.
+    """
     try:
         # Create a temporary directory for the zip file
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/app/utils/backup.py
+++ b/app/utils/backup.py
@@ -22,6 +22,38 @@ class BackupError(Exception):
     pass
 
 
+def _safe_extractall(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract a tar archive into ``dest`` while blocking path traversal.
+
+    Older Python releases (< 3.12) don't support the ``filter='data'``
+    argument to :py:meth:`tarfile.TarFile.extractall`, so we manually
+    validate each member's destination against the target directory.
+    Members whose resolved path escapes ``dest``, absolute paths, and
+    symlinks/hard-links that point outside ``dest`` are rejected.
+
+    See CVE-2007-4559 / PEP 706 for background.
+    """
+    dest_root = dest.resolve()
+    for member in tar.getmembers():
+        member_path = (dest_root / member.name).resolve()
+        try:
+            member_path.relative_to(dest_root)
+        except ValueError:
+            raise BackupError(
+                f"Refusing to extract tar member outside dest: {member.name!r}"
+            )
+        if member.issym() or member.islnk():
+            link_target = (member_path.parent / member.linkname).resolve()
+            try:
+                link_target.relative_to(dest_root)
+            except ValueError:
+                raise BackupError(
+                    f"Refusing to extract tar link outside dest: {member.name!r}"
+                    f" -> {member.linkname!r}"
+                )
+    tar.extractall(dest)
+
+
 def create_backup(
     db_session,
     backup_name: Optional[str] = None,
@@ -284,12 +316,22 @@ def restore_backup(
     
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        
+
         try:
-            # Extract archive
+            # Extract archive. Use the 'data' extraction filter introduced
+            # in Python 3.12 (PEP 706) to block path traversal, absolute
+            # paths, symlinks pointing outside the destination, and special
+            # file types inside the tarball (CVE-2007-4559 family of bugs).
+            # We pass it as a positional/keyword argument; on Python < 3.12
+            # we fall back to a manual safety check.
             logger.info(f"Extracting backup archive: {archive_path}")
             with tarfile.open(archive_path, "r:gz") as tar:
-                tar.extractall(temp_path)
+                try:
+                    tar.extractall(temp_path, filter="data")
+                except TypeError:
+                    # Older Python without filter= support: validate members
+                    # manually before extracting to prevent path traversal.
+                    _safe_extractall(tar, temp_path)
             
             # Find extracted backup directory
             backup_dirs = list(temp_path.iterdir())


### PR DESCRIPTION
## Summary

Multiple unauthenticated routes leaked credentials, allowed anonymous configuration changes, or accepted user-controlled filenames without path-traversal protection. Grouped together because they share the same root cause (missing dependencies on `require_admin_flexible`) and overlap on the same files.

### Critical — unauthenticated endpoints

- `app/routers/settings.py:48 GET /api/settings/debug/azure` — required no auth; dumped raw Azure deployment settings and unmasked raw rows from the `settings` table.
- `app/routers/settings.py:99 GET /api/settings/setup-config` — returned the cleartext **OpenAI** and **Azure OpenAI** API keys to anonymous callers.
- `app/routers/settings.py:614 GET /api/settings/export` — exported every row from the `settings` table (including API keys and the JWT secret) for anyone.
- `app/routers/settings.py:631 POST /api/settings/import` — let an anonymous attacker **overwrite every setting** (including `jwt_secret_key`, `secret_key`, API keys, storage folder paths) by POSTing a JSON file.
- `app/routers/settings.py:571 POST /api/settings/config/ocr-tools` — anonymous callers could rewrite `tesseract_path` / `poppler_path` to point at arbitrary binaries that the server later executes. Effectively an RCE primitive.
- `app/routers/settings.py:531/554/594 POST /api/settings/config/{ai-limits,file-settings,folders}` — anonymous changes to AI limits, allowed upload extensions, and storage folder paths.
- `app/routers/settings.py:257 GET /api/settings/ai-provider/status` — anonymous outbound API call + AI configuration disclosure.
- `app/routers/settings.py:665 POST /api/settings/backup` — anonymous trigger of full configuration backup.
- `app/routers/settings.py:732 GET /api/settings/logs/download` — anonymous log archive download.
- `app/routers/health.py:255 GET /api/health/metrics` and `:455 GET /api/health/security` — leaked user/admin counts, recent login telemetry and filesystem layout to anonymous callers.

All of the above now require `require_admin_flexible`.

### Privilege escalation

- `app/routers/settings.py:186 GET /api/settings/extended` previously required only the `settings.read` permission. The `admin_fix.py` editor role grants `settings.read`, so a non-admin editor could read the cleartext OpenAI/Azure keys and `secret_key`. Tightened to admin-only.

### Path traversal / archive extraction

- `app/routers/backup.py:205,251 /restore/{backup_filename}` and `/delete/{backup_filename}` joined the user-supplied `backup_filename` to `data/backups` with no validation. New `_resolve_backup_path()` enforces an allow-list character set and verifies the resolved path stays inside `data/backups`.
- `app/routers/settings.py:718 GET /api/settings/backup/{backup_id}` — same treatment.
- `app/utils/backup.py:292` used `tar.extractall(temp_path)` with no member filtering. Crafted archives can write outside the destination (CVE-2007-4559 family). Now uses `filter="data"` (PEP 706, Python 3.12+) with a manual fallback validator (`_safe_extractall`) for older interpreters.

### Other fixes

- `app/config.py` — replaced the static `secret_key="your-secret-key-change-in-production"` default with a per-process random key. The published default was being used to sign tokens whenever an admin had not overridden it; anyone with source access could forge them.
- `app/routers/documents.py:377` — uploaded documents were saved world-readable (0644). Documents typically contain invoices, contracts and ID scans, so the upload now uses owner-only (0600) permissions.

## Test plan

- [ ] Without a session, hit each of the now-protected endpoints (`/api/settings/export`, `/api/settings/setup-config`, `/api/settings/import`, `/api/settings/config/ocr-tools`, `/api/health/metrics`, `/api/health/security`, etc.) and confirm 401/403.
- [ ] With an admin session, repeat and confirm the original behavior is intact.
- [ ] With a non-admin editor session, hit `GET /api/settings/extended` and confirm 403 (was 200 leaking keys).
- [ ] `GET /api/settings/backup/../../etc/passwd` returns 400, not the file. Same for `POST /api/backup/restore/..%2fetc%2fpasswd`.
- [ ] Create a normal backup via `POST /api/settings/backup` as an admin, then download it. Restore should still work end-to-end.
- [ ] Restore a benign tarball through `/api/backup/restore/{name}` and verify success. Craft a tarball with an entry named `../etc/escape.txt`; restore should fail with a `BackupError` and `/etc/escape.txt` must not appear.
- [ ] Upload a document and verify `ls -l data/staging/<file>` shows `-rw-------` instead of `-rw-r--r--`.
- [ ] Restart the app twice and verify a missing `secret_key` setting yields a fresh random in-memory key each restart (logs/tokens minted before restart will no longer verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)